### PR TITLE
Using different approach to get the User media #16

### DIFF
--- a/webapp/src/actions/index.js
+++ b/webapp/src/actions/index.js
@@ -261,12 +261,13 @@ export function endCall() {
 }
 
 function getUserMedia(cb) {
-    navigator.mediaDevices.getUserMedia({video: true, audio: true}).then((stream) => {
+    try {
+        const stream = await navigator.mediaDevices.getUserMedia({video: true, audio: true});
         cb(null, stream);
-    }).catch((e) => {
+    } catch (e) {
         console.log(`Cannot initialize camera/microphone: ${e}`); //eslint-disable-line
         cb(e, null);
-    });
+    }
 }
 
 function createPeer(stream, initiator, userId, peerId) {


### PR DESCRIPTION
According to: https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia
There's a note about:
```
it's possible for the returned promise to neither resolve nor reject, as the user is not required to make a choice at all and may simply ignore the request.
```

So following the electron example for capturing:
https://www.electronjs.org/docs/api/desktop-capturer

Switching to await should allow it to work under those circustances